### PR TITLE
Update github api authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,4 @@ The git browser for kodi has been updated to be Python 3 compatible with all the
 <br />
 *Note: this still may have issues*<br />
 To Do:<br />
-- Update the github API to push the key in the header rather than a query parameter
-- Go through properly to make sure there is no errors
+- Go through properly to make sure there are no errors

--- a/commoncore/baseapi.py
+++ b/commoncore/baseapi.py
@@ -228,6 +228,14 @@ class CACHABLE_API(BASE_API):
     def request(self, uri, query=None, data=None, append_base=True, headers=None, auth=None, method=None, timeout=None, encode_data=True, cache_limit=0):
         query = self.prepair_query(query)
         request_args = (uri,)
+
+        if headers is None:
+            # Use default headers
+            headers = self.default_headers
+        else:
+            # Merge the default headers with the provided headers
+            headers = {**self.default_headers, **headers}
+
         request_kwargs = {"query": query, "data": data, "append_base": append_base, "headers": headers, "auth": auth, "method": method, "timeout": timeout, "cache_limit": cache_limit, "encode_data": encode_data}
         self.set_user_agent(headers)
         if auth is not None:

--- a/github/github_api.py
+++ b/github/github_api.py
@@ -69,18 +69,19 @@ class GitHubAPI(CACHABLE_API):
     default_return_type = 'json'
     base_url = "https://api.github.com"
 
+    def __init__(self):
+        super(GitHubAPI, self).__init__()
+        self.access_token = kodi.get_setting('access_token')
+        if self.access_token:
+            self.default_headers = {'Authorization': 'token {}'.format(self.access_token)} if self.access_token else {}
+
     def prepair_request(self):
         kodi.sleep(random.randint(100, 250)) # random delay 50-250 ms
 
     def build_url(self, uri, query, append_base):
         if append_base:
             url = self.base_url + uri
-        token = kodi.get_setting('access_token')
-        if token:
-            if query is None:
-                query = {"access_token": token}
-            else:
-                query["access_token"] = token
+
         if query is not None:
             query = urlencode(query)
             for r in [('%3A', ":"), ("%2B", "+")]:


### PR DESCRIPTION
The github API now passes the auth key in the header instead of using the old method of passing as a query string parameter

This update gets rid of many of the error msgs when clicking into different options within the git browser plugin, but the github api calls themselves seem to have changed since this plugin was created and many of them no longer return results the way it seems they were designed to. Unless I am mistaken, I believe most if not all options that use the github api will need to be rewritten to use api methods that actually return data properly.