### PR TITLE
Restore "Search by repo title" functionality

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -352,23 +352,6 @@ def github_install():
     addon_id = re.sub("-[\d\.]+zip$", "", kodi.arg('file'))
     github_installer.GitHub_Installer(addon_id, kodi.arg('url'), kodi.arg('full_name'), kodi.vfs.join("special://home", "addons"))
 
-    r = kodi.dialog_confirm(
-        kodi.get_name(),
-        'Click Continue to install more addons or ',
-        'Restart button to finalize addon installation',
-        yes='Restart',
-        no='Continue'
-    )
-
-    if r:
-        import sys
-        import xbmc
-        if sys.platform in ['linux', 'linux2', 'win32']:
-            xbmc.executebuiltin('RestartApp')
-        else:
-            xbmc.executebuiltin('ShutDown')
-
-
 @kodi.register('browse_repository', False)
 def browse_repository():
     xml = github.browse_repository(kodi.arg('url'))

--- a/addon.py
+++ b/addon.py
@@ -94,26 +94,17 @@ def search():
             return
 
         for i in results['items']:
-
             user = i['owner']['login']
 
-            response = github.find_zips(user)
-            if response is None:
+            response = github.find_latest_release_zips(user, i['name'])
+
+            if response is None or response.get('message') is not None:
                 continue
 
-            for r in github.sort_results(response['items']):
-                url = github.get_download_url(r['repository']['full_name'], r['path'])
+            for r in github.sort_results(response['assets']):
+                url = r['browser_download_url']
                 menu = kodi.context_menu()
-                if r['is_repository']:
-                    menu.add('Browse Repository Contents', {"mode": "browse_repository", "url": url, "file": r['name'], "full_name": "%s/%s" % (q, r['repository']['name'])})
-                if r['is_feed']:
-                    r['display'] = "[COLOR yellow]%s[/COLOR]" % r['name']
-                    kodi.add_menu_item({'mode': 'install_feed', "url": url}, {'title': r['name']}, menu=menu, icon='null')
-                elif r['is_installer']:
-                    r['display'] = "[COLOR orange]%s[/COLOR]" % r['name']
-                    kodi.add_menu_item({'mode': 'install_batch', "url": url}, {'title': r['name'], 'display': r['display']}, menu=menu, icon='null')
-                else:
-                    kodi.add_menu_item({'mode': 'github_install', "url": url, "user": q, "file": r['name'], "full_name": "%s/%s" % (q, r['repository']['name'])}, {'title': r['name']}, menu=menu, icon='null')
+                kodi.add_menu_item({'mode': 'github_install', "url": url, "user": user, "file": r['name'], "full_name": "%s/%s" % (user, i['name'])}, {'title': f"{user}/{i['name']}/{r['name']}"}, menu=menu, icon='null')
 
     @dispatcher.register('addonid')
     def addonid():
@@ -363,7 +354,7 @@ def github_install():
 
     r = kodi.dialog_confirm(
         kodi.get_name(),
-        'Click Continue to install more addons or',
+        'Click Continue to install more addons or ',
         'Restart button to finalize addon installation',
         yes='Restart',
         no='Continue'

--- a/commoncore/baseapi.py
+++ b/commoncore/baseapi.py
@@ -264,7 +264,7 @@ class CACHABLE_API(BASE_API):
         except (requests.exceptions.Timeout, requests.exceptions.ConnectionError, requests.exceptions.TooManyRedirects) as err_str:
             self.handel_error(connectionException(err_str), None, request_args, request_kwargs)
 
-        if response.status_code in ( requests.codes.ok, 201 ):
+        if response.status_code in ( requests.codes.ok, 201 ) or (response.status_code == 404 and response.json().get('message') is not None):
             return self.process_response( url, response, cache_limit, request_args, request_kwargs)
 
         return self.handel_error(responseException(response.status_code), response, request_args, request_kwargs)

--- a/commoncore/kodi/addon.py
+++ b/commoncore/kodi/addon.py
@@ -147,15 +147,15 @@ def refresh(plugin_url=None):
         run_command("Container.Refresh(%s)" % plugin_url)
 
 def execute_url(plugin_url):
-    cmd = 'XBMC.RunPlugin(%s)' % (plugin_url)
+    cmd = 'RunPlugin(%s)' % (plugin_url)
     run_command(cmd)
 
 def execute_script(script):
-    cmd = 'XBMC.RunScript(%s)' % (script)
+    cmd = 'RunScript(%s)' % (script)
     run_command(cmd)
 
 def execute_addon(addon_id):
-    cmd = 'XBMC.RunAddon(%s)' % addon_id
+    cmd = 'RunAddon(%s)' % addon_id
     run_command(cmd)
 
 def navigate_to(query):
@@ -163,14 +163,14 @@ def navigate_to(query):
     go_to_url(plugin_url)
 
 def go_to_url(plugin_url):
-    cmd = "XBMC.Container.Update(%s)" % plugin_url
+    cmd = 'Container.Update(%s)' % plugin_url
     run_command(cmd)
 
 def play_url(plugin_url, isFolder=False):
     if isFolder:
-        cmd = 'XBMC.PlayMedia(%s,True)' % (plugin_url)
+        cmd = 'PlayMedia(%s,True)' % (plugin_url)
     else:
-        cmd = 'XBMC.PlayMedia(%s)' % (plugin_url)
+        cmd = 'PlayMedia(%s)' % (plugin_url)
     run_command(cmd)
 
 play_media = play_url
@@ -248,9 +248,9 @@ class ContextMenu:
             plugin_url =  "%s?%s" % (sys.argv[0],  urlencode(arguments))
 
         if script:
-            cmd = 'XBMC.RunPlugin(%s)' % (plugin_url)
+            cmd = 'RunPlugin(%s)' % (plugin_url)
         else:
-            cmd = "XBMC.Container.Update(%s)" % plugin_url
+            cmd = 'Container.Update(%s)' % plugin_url
         return cmd
 
     def get(self):

--- a/commoncore/kodi/ui.py
+++ b/commoncore/kodi/ui.py
@@ -34,12 +34,12 @@ def close_busy_dialog():
     xbmc.executebuiltin( "Dialog.Close(busydialog)" )
 
 def notify(heading, message, timeout=1500, image=vfs.join(get_path(), 'icon.png')):
-    cmd = "XBMC.Notification(%s, %s, %s, %s)" % (heading, message, timeout, image)
+    cmd = "Notification(%s, %s, %s, %s)" % (heading, message, timeout, image)
     xbmc.executebuiltin(cmd)
 
 def handel_error(heading, message, timeout=3000):
     image=vfs.join(ARTWORK, 'error.png')
-    cmd = "XBMC.Notification(%s, %s, %s, %s)" % (heading, message, timeout, image)
+    cmd = "Notification(%s, %s, %s, %s)" % (heading, message, timeout, image)
     xbmc.executebuiltin(cmd)
     sys.exit()
 
@@ -161,9 +161,9 @@ class ContextMenu:
             plugin_url =  "%s?%s" % (sys.argv[0],  urlencode(arguments))
 
         if script:
-            cmd = 'XBMC.RunPlugin(%s)' % (plugin_url)
+            cmd = 'RunPlugin(%s)' % (plugin_url)
         else:
-            cmd = "XBMC.Container.Update(%s)" % plugin_url
+            cmd = 'Container.Update(%s)' % plugin_url
         return cmd
 
     def get(self):

--- a/github/github_installer.py
+++ b/github/github_installer.py
@@ -263,7 +263,7 @@ class GitHub_Installer():
 
     def enable_addon(self, addon_id):
         try:
-            if addon_id in ['xbmc.python', 'xbmc.gui'] or kodi.get_condition_visiblity('System.HasAddon(%s)' % addon_id) == 1:
+            if addon_id in ['xbmc.python', 'xbmc.gui'] or kodi.get_condition_visiblity(f'System.HasAddon({addon_id})') == 1:
                 return True
             kodi.log("Enable Addon: %s" % addon_id)
             kodi.kodi_json_request("Addons.SetAddonEnabled", {"addonid": addon_id, "enabled": True})

--- a/github/github_installer.py
+++ b/github/github_installer.py
@@ -113,14 +113,15 @@ class GitHub_Installer():
         # Initiate install routine
         self.install_addon(addon_id, url, full_name, master)
 
-
         completed = list(reversed(self.completed))
         if not quiet:
             pb = kodi.ProgressBar()
             pb.new('Enabling Addons', len(completed)+1)
             pb.update_subheading('Building Addon List')
-        kodi.run_command("XBMC.UpdateLocalAddons()")
+
+        kodi.run_command("UpdateLocalAddons")
         kodi.sleep(500)
+
         for addon_id in completed:
             if not quiet:
                 #percent = 100* (completed.index(addon_id) / len(completed))
@@ -132,7 +133,7 @@ class GitHub_Installer():
         if not quiet:
             pb.next("Looking for Updates", "")
         kodi.sleep(500)
-        kodi.run_command('XBMC.UpdateAddonRepos')
+        kodi.run_command('UpdateAddonRepos')
 
         # Enable installed addons
         if not self.quiet:
@@ -263,7 +264,7 @@ class GitHub_Installer():
 
     def enable_addon(self, addon_id):
         try:
-            if addon_id in ['xbmc.python', 'xbmc.gui'] or kodi.get_condition_visiblity(f'System.HasAddon({addon_id})') == 1:
+            if addon_id in ['xbmc.python', 'xbmc.gui'] or kodi.get_condition_visiblity(f'System.HasAddon({addon_id})') == 0:
                 return True
             kodi.log("Enable Addon: %s" % addon_id)
             kodi.kodi_json_request("Addons.SetAddonEnabled", {"addonid": addon_id, "enabled": True})


### PR DESCRIPTION
@azzy9 the "Search by repo title" option is now working again. This may be an oversimplification of the original functionality because I'm a little unsure of how the original plugin worked. The new functionality basically finds all repos that match the name given and then returns all zip files from the most recent release for each repo. Assuming it returns 1 or more zip file matches, you can click the zip file name to install it, which it does. There are 2 main problems or shortcomings with this plugin installation though:

1) Kodi must be closed and reopened for the newly installed plugin to show up in the list of plugins/add-ons. This doesn't seem to be a new problem since the original code prompts you to restart or continue if you want to install more plugins. I did bit of searching and so far I haven't been able to find a method of refreshing the plugin list while Kodi is running. I also notice that on windows 10 choosing the Restart option always freezes Kodi and I have to manually end the task via task mgr although perhaps it is just me (?)

2) The plugin is installed in the disabled state, and must be manually enabled after restarting Kodi. The old code has a method of calling the "Addons.SetAddonEnabled" api which DOES NOT WORK with the initial install as it always fails with this msg: `{'error': {'code': -32602, 'message': 'Invalid params.'}, 'id': 1, 'jsonrpc': '2.0'}`. I explored this a bit already and the code to automatically activate the plugin does actually work, but only after restarting Kodi. Therefore, it seems that it is not possible to auto-enable the plugin after installing until Kodi is aware of the plugin in the list of add-ons. One possible workaround idea would be to have the Git Browser "remember" the plugins that it installed and upon restarting Kodi it can review the list of installed plugins and try enabling them at that time. This seems like overkill to me and it would be much nicer if the there was a way to refresh the internal list of plugins without restarting which I'm sure would allow the "Addons.SetAddonEnabled" api to work right afterwards

Long story short, I feel this is a step in the right direction, even if it isn't as perfect as I would like. I'd love to hear if you have any ideas of how to resolve either of the 2 main issues